### PR TITLE
Let getSeriesByName properly escape series name

### DIFF
--- a/compat/index.js
+++ b/compat/index.js
@@ -102,7 +102,7 @@ var Client = (function(){var PRS$0 = (function(o,t){o["__proto__"]={"a":t};retur
      */
 
     proto$0.getSeriesByName = function(name, callback) {
-        var url = (("" + (this.baseURL)) + ("/GetSeries.php?seriesname=" + name) + ("&language=" + (this.language)) + "");
+        var url = (("" + (this.baseURL)) + ("/GetSeries.php?seriesname=" + (encodeURIComponent(name))) + ("&language=" + (this.language)) + "");
 
         return sendRequest({url: url, lang: this.language}, RESPONSE_TYPE.XML, function(response, done) {
             response = (response && response.Data) ? response.Data.Series : null;

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ class Client {
      */
 
     getSeriesByName(name, callback) {
-        const url = `${this.baseURL}/GetSeries.php?seriesname=${name}&language=${this.language}`;
+        const url = `${this.baseURL}/GetSeries.php?seriesname=${encodeURIComponent(name)}&language=${this.language}`;
 
         return sendRequest({url: url, lang: this.language}, RESPONSE_TYPE.XML, function(response, done) {
             response = (response && response.Data) ? response.Data.Series : null;

--- a/test/tests/search-by-name.js
+++ b/test/tests/search-by-name.js
@@ -70,6 +70,15 @@ module.exports = function(TVDBClient) {
     				done();
     			});
     		});
+
+            it("should return an array of available matches for the series search \"&The Simpsons\"", function(done) {
+                var client = new TVDBClient(API_KEY);
+                client.getSeriesByName("&The Simpsons", function(error, response) {
+                    assert.ifError(error);
+                    assert.equal("object", typeof response);
+                    done();
+                });
+            });
         });
 
         describe("Promise API", function() {
@@ -158,6 +167,15 @@ module.exports = function(TVDBClient) {
     			    })
     			    .then(done);
     		});
+
+            it("should return an array of available matches for the series search \"&The Simpsons\"", function(done) {
+                var client = new TVDBClient(API_KEY);
+                client.getSeriesByName("&The Simpsons")
+                    .then(function(response) {
+                        assert.equal("object", typeof response);
+                    })
+                    .then(done, done);
+            });
         });
     });
 };


### PR DESCRIPTION
The name variable wasn't escaped / URI-encoded properly, resulting in unexpected behaviour. For example, searching for "Young & Hungry" would only search for "Young".

I've only added encodeURIComponent() around the series name in getSeriesByName. There are some other candidates for adding it (preferably for all dynamic URL components), but this is the only one that is very likely to contain conflicting URI characters, while being passed in externally, possibly from user input.