### PR TITLE
Various test fixes and cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
     "test": "gulp && mocha test/runner",
     "transpile": "gulp"
   },
-  "licence": "MIT"
+  "license": "MIT"
 }

--- a/test/tests/episode.js
+++ b/test/tests/episode.js
@@ -38,22 +38,20 @@ module.exports = function(TVDBClient) {
                         assert.equal("4768125", response.id);
                         assert.equal("2014-03-30", response.FirstAired);
                     })
-                    .catch(function(error) {
-                        assert.ifError(error);
-                    })
-                    .then(done);
+                    .then(done, done);
             });
 
             it("should return an error for a episode search with an invalid id", function(done) {
                 var client = new TVDBClient(API_KEY);
                 client.getEpisodeById("0")
-                    .then(function(response) {
-                        assert.equal(null, response);
-                    })
-                    .catch(function(error) {
-                        assert.notEqual(null, error);
-                    })
-                    .then(done);
+                    .then(
+                        function(response) {
+                            assert(false);
+                        }, function(error) {
+                            assert.notEqual(null, error);
+                        }
+                    )
+                    .then(done, done);
             });
         });
     });

--- a/test/tests/find-actors.js
+++ b/test/tests/find-actors.js
@@ -25,10 +25,7 @@ module.exports = function(TVDBClient) {
                     .then(function(response) {
                         assert.equal("object", typeof response);
                     })
-                    .catch(function(error) {
-                        assert.ifError(error);
-                    })
-                    .then(done);
+                    .then(done, done);
             });
         });
     });

--- a/test/tests/find-banners.js
+++ b/test/tests/find-banners.js
@@ -25,10 +25,7 @@ module.exports = function(TVDBClient) {
                     .then(function(response) {
                         assert.equal("object", typeof response);
                     })
-                    .catch(function(error) {
-                        assert.ifError(error);
-                    })
-                    .then(done);
+                    .then(done, done);
             });
         });
     });

--- a/test/tests/language.js
+++ b/test/tests/language.js
@@ -10,7 +10,7 @@ module.exports = function(TVDBClient) {
             assert.equal("en", client.language);
         });
 
-        it("should return the language as \"pt\" if initilaised with the language \"pt\"", function() {
+        it("should return the language as \"pt\" if initialised with the language \"pt\"", function() {
             var client = new TVDBClient(API_KEY, "pt");
             assert.equal("pt", client.language);
         });
@@ -23,7 +23,7 @@ module.exports = function(TVDBClient) {
 
         describe("Callback API", function() {
 
-            it("should return an array of available langauages", function(done) {
+            it("should return an array of available languages", function(done) {
                 var client = new TVDBClient(API_KEY);
                 client.getLanguages(function(error, response) {
                     assert.ifError(error);
@@ -44,7 +44,7 @@ module.exports = function(TVDBClient) {
 
         describe("Promise API", function() {
 
-            it("should return an array of available langauages", function(done) {
+            it("should return an array of available languages", function(done) {
                 var client = new TVDBClient(API_KEY);
                 client.getLanguages()
                     .then(function(response) {

--- a/test/tests/language.js
+++ b/test/tests/language.js
@@ -50,22 +50,20 @@ module.exports = function(TVDBClient) {
                     .then(function(response) {
                         assert.equal("object", typeof response);
                     })
-                    .catch(function(error) {
-                        assert.ifError(error);
-                    })
-                    .then(done);
+                    .then(done, done);
             });
 
             it("should return an error if getLanguages is called without a valid API key", function(done) {
                 var client = new TVDBClient("test123");
                 client.getLanguages()
-                    .then(function(response) {
-                        assert.equal(null, response);
-                    })
-                    .catch(function(error) {
-                        assert.notEqual(null, error);
-                    })
-                    .then(done);
+                    .then(
+                        function(response) {
+                            assert(false);
+                        }, function(error) {
+                            assert.notEqual(null, error);
+                        }
+                    )
+                    .then(done, done);
             });
         });
     });

--- a/test/tests/search-by-id.js
+++ b/test/tests/search-by-id.js
@@ -56,10 +56,7 @@ module.exports = function(TVDBClient) {
                         assert.equal("object", typeof response);
                         assert.equal("246151", response.id);
                     })
-                    .catch(function(error) {
-                        assert.ifError(error);
-                    })
-                    .then(done);
+                    .then(done, done);
             });
 
             it("should return an object of the series and its episodes with id \"246151\"", function(done) {
@@ -70,34 +67,33 @@ module.exports = function(TVDBClient) {
                         assert.equal("246151", response.id);
                         assert.equal("object", typeof response.Episodes);
                     })
-                    .catch(function(error) {
-                        assert.ifError(error);
-                    })
-                    .then(done);
+                    .then(done, done);
             });
 
             it("should return an error for a series search with an invalid language", function(done) {
                 var client = new TVDBClient(API_KEY, "00");
                 client.getSeriesAllById("246121")
-                    .then(function(response) {
-                        assert.equal(null, response);
-                    })
-                    .catch(function(error) {
-                        assert.notEqual(null, error);
-                    })
-                    .then(done);
+                    .then(
+                        function(response) {
+                            assert(false);
+                        }, function(error) {
+                            assert.notEqual(null, error);
+                        }
+                    )
+                    .then(done, done);
             });
 
             it("should return an error for a series search with an invalid id", function(done) {
                 var client = new TVDBClient(API_KEY);
                 client.getSeriesAllById("0")
-                    .then(function(response) {
-                        assert.equal(null, response);
-                    })
-                    .catch(function(error) {
-                        assert.notEqual(null, error);
-                    })
-                    .then(done);
+                    .then(
+                        function(response) {
+                            assert(false);
+                        }, function(error) {
+                            assert.notEqual(null, error);
+                        }
+                    )
+                    .then(done, done);
             });
         });
     });

--- a/test/tests/search-by-name.js
+++ b/test/tests/search-by-name.js
@@ -34,15 +34,6 @@ module.exports = function(TVDBClient) {
                 });
             });
 
-            it("should return an error for a blank series search", function(done) {
-                var client = new TVDBClient(API_KEY);
-                client.getSeriesByName("", function(error, response) {
-                    assert.notEqual(null, error);
-                    assert.equal(null, response);
-                    done();
-                });
-            });
-
             it("should return null for the series search \"Planeta Terra\" with the language set to \"en\"", function(done) {
                 var client = new TVDBClient(API_KEY);
                 client.getSeriesByName("Planeta Terra", function(error, response) {
@@ -103,18 +94,6 @@ module.exports = function(TVDBClient) {
                     })
                     .catch(function(error) {
                         assert.ifError(error);
-                    })
-                    .then(done);
-            });
-
-            it("should return an error for a blank series search", function(done) {
-                var client = new TVDBClient(API_KEY);
-                client.getSeriesByName("")
-                    .then(function(response) {
-                        assert.equal(null, response);
-                    })
-                    .catch(function(error) {
-                        assert.notEqual(null, error);
                     })
                     .then(done);
             });

--- a/test/tests/search-by-name.js
+++ b/test/tests/search-by-name.js
@@ -80,10 +80,7 @@ module.exports = function(TVDBClient) {
                     .then(function(response) {
                         assert.equal("object", typeof response);
                     })
-                    .catch(function(error) {
-                        assert.ifError(error);
-                    })
-                    .then(done);
+                    .then(done, done);
             });
 
             it("should return null for the series search \"asdas\"", function(done) {
@@ -92,22 +89,20 @@ module.exports = function(TVDBClient) {
                     .then(function(response) {
                         assert.equal(null, response);
                     })
-                    .catch(function(error) {
-                        assert.ifError(error);
-                    })
-                    .then(done);
+                    .then(done, done);
             });
 
             it("should return an error for a blank series search", function(done) {
                 var client = new TVDBClient(API_KEY);
                 client.getSeriesByName("")
-                    .then(function(response) {
-                        assert.equal(null, response);
-                    })
-                    .catch(function(error) {
-                        assert.notEqual(null, error);
-                    })
-                    .then(done);
+                    .then(
+                        function(response) {
+                            assert(false);
+                        }, function(error) {
+                            assert.notEqual(null, error);
+                        }
+                    )
+                    .then(done, done);
             });
 
             it("should return null for the series search \"Planeta Terra\" with the language set to \"en\"", function(done) {
@@ -116,10 +111,7 @@ module.exports = function(TVDBClient) {
                     .then(function(response) {
                         assert.equal(null, response);
                     })
-                    .catch(function(error) {
-                        assert.ifError(error);
-                    })
-                    .then(done);
+                    .then(done, done);
             });
 
             it("should return an array of available matches for the series search \"Planeta Terra\" with the language set to \"pt\"", function(done) {
@@ -128,10 +120,7 @@ module.exports = function(TVDBClient) {
                     .then(function(response) {
                         assert.equal("object", typeof response);
                     })
-                    .catch(function(error) {
-                        assert.ifError(error);
-                    })
-                    .then(done);
+                    .then(done, done);
             });
 
             it("should return an array even when there's only one result returned", function(done) {
@@ -141,10 +130,7 @@ module.exports = function(TVDBClient) {
                         assert.equal("object", typeof response);
                         assert.equal(1, response.length);
                     })
-                    .catch(function(error) {
-                        assert.ifError(error);
-                    })
-                    .then(done);
+                    .then(done, done);
             });
 
             it("should return an array of available matches for the series search \"&The Simpsons\"", function(done) {

--- a/test/tests/search-by-name.js
+++ b/test/tests/search-by-name.js
@@ -8,8 +8,8 @@ module.exports = function(TVDBClient) {
         describe("Callback API", function() {
 
             it("should return an array of available matches for the series search \"The Simpsons\"", function(done) {
-                var tvdb = new TVDBClient(API_KEY);
-                tvdb.getSeriesByName("The Simpsons", function(error, response) {
+                var client = new TVDBClient(API_KEY);
+                client.getSeriesByName("The Simpsons", function(error, response) {
                     assert.ifError(error);
                     assert.equal("object", typeof response);
                     done();
@@ -75,8 +75,8 @@ module.exports = function(TVDBClient) {
         describe("Promise API", function() {
 
             it("should return an array of available matches for the series search \"The Simpsons\"", function(done) {
-                var tvdb = new TVDBClient(API_KEY);
-                tvdb.getSeriesByName("The Simpsons")
+                var client = new TVDBClient(API_KEY);
+                client.getSeriesByName("The Simpsons")
                     .then(function(response) {
                         assert.equal("object", typeof response);
                     })

--- a/test/tests/search-by-name.js
+++ b/test/tests/search-by-name.js
@@ -61,15 +61,15 @@ module.exports = function(TVDBClient) {
                 });
             });
 
-    		it("should return an array even when there's only one result returned", function(done) {
-    			var client = new TVDBClient(API_KEY);
-    			client.getSeriesByName("Bob's Burgers", function(error, response) {
-    				assert.ifError(error);
-    				assert.equal("object", typeof response);
-    				assert.equal(1, response.length);
-    				done();
-    			});
-    		});
+            it("should return an array even when there's only one result returned", function(done) {
+                var client = new TVDBClient(API_KEY);
+                client.getSeriesByName("Bob's Burgers", function(error, response) {
+                    assert.ifError(error);
+                    assert.equal("object", typeof response);
+                    assert.equal(1, response.length);
+                    done();
+                });
+            });
 
             it("should return an array of available matches for the series search \"&The Simpsons\"", function(done) {
                 var client = new TVDBClient(API_KEY);
@@ -155,18 +155,18 @@ module.exports = function(TVDBClient) {
                     .then(done);
             });
 
-    		it("should return an array even when there's only one result returned", function(done) {
-    			var client = new TVDBClient(API_KEY);
-    			client.getSeriesByName("Bob's Burgers")
-    			    .then(function(response) {
-    					assert.equal("object", typeof response);
-    					assert.equal(1, response.length);
-    			    })
-    			    .catch(function(error) {
-    			        assert.ifError(error);
-    			    })
-    			    .then(done);
-    		});
+            it("should return an array even when there's only one result returned", function(done) {
+                var client = new TVDBClient(API_KEY);
+                    client.getSeriesByName("Bob's Burgers")
+                    .then(function(response) {
+                        assert.equal("object", typeof response);
+                        assert.equal(1, response.length);
+                    })
+                    .catch(function(error) {
+                        assert.ifError(error);
+                    })
+                    .then(done);
+            });
 
             it("should return an array of available matches for the series search \"&The Simpsons\"", function(done) {
                 var client = new TVDBClient(API_KEY);

--- a/test/tests/search-by-remote.js
+++ b/test/tests/search-by-remote.js
@@ -50,10 +50,7 @@ module.exports = function(TVDBClient) {
                         assert.equal("81189", response.id);
                         assert.equal("Breaking Bad", response.SeriesName);
                     })
-                    .catch(function(error) {
-                        assert.ifError(error);
-                    })
-                    .then(done);
+                    .then(done, done);
             });
 
             it("should return an object of the series with zap2it id \"EP01009396\"", function(done) {
@@ -64,23 +61,21 @@ module.exports = function(TVDBClient) {
                         assert.equal("81189", response.id);
                         assert.equal("Breaking Bad", response.SeriesName);
                     })
-                    .catch(function(error) {
-                        assert.ifError(error);
-                    })
-                    .then(done);
+                    .then(done, done);
             });
 
 
             it("should return an error for a series search with an invalid id", function(done) {
                 var client = new TVDBClient(API_KEY);
                 client.getSeriesAllById("0")
-                    .then(function(response) {
-                        assert.equal(null, response);
-                    })
-                    .catch(function(error) {
-                        assert.notEqual(null, error);
-                    })
-                    .then(done);
+                    .then(
+                        function(response) {
+                            assert(false);
+                        }, function(error) {
+                            assert.notEqual(null, error);
+                        }
+                    )
+                    .then(done, done);
             });
         });
     });

--- a/test/tests/time.js
+++ b/test/tests/time.js
@@ -25,10 +25,7 @@ module.exports = function(TVDBClient) {
                     .then(function(response) {
                         assert.equal("string", typeof response);
                     })
-                    .catch(function(error) {
-                        assert.ifError(error);
-                    })
-                    .then(done);
+                    .then(done, done);
             });
         });
     });

--- a/test/tests/update.js
+++ b/test/tests/update.js
@@ -44,23 +44,21 @@ module.exports = function(TVDBClient) {
                         assert.equal("object", typeof response.Episode);
                         assert.equal("object", typeof response.Series);
                     })
-                    .catch(function(error) {
-                        assert.ifError(error);
-                    })
-                    .then(done);
+                    .then(done, done);
             });
 
             it("should return a promise error when getting updates with an invalid time", function(done) {
                 var client = new TVDBClient(API_KEY);
 
                 client.getUpdates("z")
-                    .then(function(response) {
-                        assert.equal(null, response);
-                    })
-                    .catch(function(error) {
-                        assert.notEqual(null, error);
-                    })
-                    .then(done);
+                    .then(
+                        function(response) {
+                            assert(false);
+                        }, function(error) {
+                            assert.notEqual(null, error);
+                        }
+                    )
+                    .then(done, done);
             });
         });
     });
@@ -105,25 +103,27 @@ module.exports = function(TVDBClient) {
             it("should return an error if getUpdateRecords is called without a valid API key", function(done) {
                 var client = new TVDBClient("test123");
                 client.getUpdateRecords("day")
-                    .then(function(response) {
-                        assert.equal(null, response);
-                    })
-                    .catch(function(error) {
-                        assert.notEqual(null, error);
-                    })
-                    .then(done);
+                    .then(
+                        function(response) {
+                            assert(false);
+                        }, function(error) {
+                            assert.notEqual(null, error);
+                        }
+                    )
+                    .then(done, done);
             });
 
             it("should return an error if getUpdateRecords is called with an invalid interval", function(done) {
                 var client = new TVDBClient(API_KEY);
                 client.getUpdateRecords("year")
-                    .then(function(response) {
-                        assert.equal(null, response);
-                    })
-                    .catch(function(error) {
-                        assert.notEqual(null, error);
-                    })
-                    .then(done);
+                    .then(
+                        function(response) {
+                            assert(false);
+                        }, function(error) {
+                            assert.notEqual(null, error);
+                        }
+                    )
+                    .then(done, done);
             });
 
             ["day", "week", "month"].forEach(function(interval) {
@@ -136,10 +136,7 @@ module.exports = function(TVDBClient) {
                             assert.equal("object", typeof response.Episode);
                             assert.equal("object", typeof response.Banner);
                         })
-                        .catch(function(error) {
-                            assert.ifError(error);
-                        })
-                        .then(done);
+                        .then(done, done);
                 })
             });
             // skipped "all" due to file size of ~50 MB


### PR DESCRIPTION
Here are a bunch of fixes for the tests. The iterations are split up into separate commits, so they should be easy to check in small chunks. As a bonus, there's a fix in package.json, unrelated to tests :smile:

The main problem (fixed in commit b3b82dc) was with the promise tests. All tests either: expect a result (_type A_), or expect an error (_type B_), and both were causing problems:

##### Type A

```js
            it("should return an array of available matches for the series search \"The Simpsons\"", function(done) {
                var tvdb = new TVDBClient(API_KEY);
                tvdb.getSeriesByName("The Simpsons")
                    .then(function(response) {
                        assert.equal("object", typeof response);
                    })
                    .catch(function(error) {
                        assert.ifError(error);
                    })
                    .then(done);
            });
```

First of all the `.catch()` is not doing much here, since it's always called with an error, which is then simply "rethrown" by the assert statement. Secondly, in case of an error, `done` is never called, because there is no 2nd argument to the last `then()`. If `done` is never called, a mocha test run will exit halfway through the tests!

##### Type B

```js
            it("should return an error for a blank series search", function(done) {
                var client = new TVDBClient(API_KEY);
                client.getSeriesByName("")
                    .then(function(response) {
                        assert.equal(null, response);
                    })
                    .catch(function(error) {
                        assert.notEqual(null, error);
                    })
                    .then(done);
            });
```

Here, a valid response (not an error) will trigger the assert in the first `.then()`, which is then caught again in the `.catch()`, turning it back into a success, which will make the test pass! The only way the test could fail, is the assert in the `.catch()`, however this is impossible since inside `catch()`, the error argument is never null. And even if it would somehow still fail/throw there, `done` will never be called, making mocha exit halfway (see _type A_).