### PR TITLE
bump node version to 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/edwellbrook/node-tvdb",
   "main": "index.js",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "repository": {
     "type": "git",

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: node:4.0.0
+box: node:6.0.0
 
 build:
   steps:


### PR DESCRIPTION
new-tvdb-api uses ES6 features like default parameters that are not supported in node 4.
As node 6 is active LTS now there should be no harm in upgrading