### PR TITLE
Fix paging when there are more than two pages

### DIFF
--- a/index.js
+++ b/index.js
@@ -390,6 +390,9 @@ class Client {
         let urlObj = url.parse(path, true);
         urlObj.query.page = response.links.next;
 
+        // remove urlObj.search to force url.format() to use urlObj.query
+        urlObj.search = undefined;
+
         const newPath = url.format(urlObj);
         return this.sendRequest(newPath, language);
     }

--- a/test/#getEpisodesBySeriesId.js
+++ b/test/#getEpisodesBySeriesId.js
@@ -42,4 +42,11 @@ describe('#getEpisodesBySeriesId', () => {
                 });
         });
     });
+
+    it('returns data from several pages', () => {
+        return new TVDB(API_KEY).getEpisodesBySeriesId(71663)
+            .then(response => {
+                expect(response).to.have.length.above(600);
+            });
+    });
 });


### PR DESCRIPTION
Apparently `url.format` preferes `urlObj.search` over `urlObj.query`.

Therefore changing `urlObj.query` only works when deleting `urlObj.search`.

Added a test case with seven pages.

Note: this is meant to be merged after #65.