### PR TITLE
Handle HTTP Errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -463,9 +463,7 @@ function logIn(apiKey) {
 
     return request(`${BASE_URL}/login`, opts)
         .then(res => checkError(res))
-        .then(res => {
-            return res.json();
-        })
+        .then(res => res.json())
         .then(json => json.token);
 }
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,10 @@
     "eslint-plugin-mocha": "^4.8.0",
     "jsdoc": "^3.4.3",
     "minami": "github:edwellbrook/minami",
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "nock": "^9.0.9",
+    "sinon": "^1.17.7",
+    "sinon-chai": "^2.8.0"
   },
   "scripts": {
     "test": "mocha test && eslint .",

--- a/test/Client.js
+++ b/test/Client.js
@@ -1,0 +1,433 @@
+'use strict';
+
+/* eslint mocha/no-synchronous-tests: "off" */
+
+const TVDB = require('..');
+const API_KEY = 'fake-api-key';
+const JWT_TOKEN = 'fake-jwt-token';
+const BASE_URL = 'https://api.thetvdb.com';
+const LIB_VERSION = require('../package.json').version;
+const API_VERSION = 'v2.1.1';
+const AV_HEADER = `application/vnd.thetvdb.${API_VERSION}`;
+const AGENT_STRING = `node-tvdb/${LIB_VERSION} (+https://github.com/edwellbrook/node-tvdb)`;
+
+const chai = require('chai');
+const expect = chai.expect;
+const nock = require('nock');
+const sinon = require('sinon');
+const Body = require('node-fetch/lib/body');
+
+chai
+.use(require('chai-as-promised'))
+.use(require('sinon-chai'));
+
+describe('Client', () => {
+
+    before(() => {
+        nock.disableNetConnect();
+    });
+
+    after(() => {
+        nock.cleanAll();
+        nock.enableNetConnect();
+    });
+
+    describe('#constructor', () => {
+
+        describe('when called with no arguments', () => {
+
+            it('should throw', () => {
+                expect(() => {
+                    return new TVDB();
+                }).to.throw(Error, 'API key is required');
+            });
+
+        });
+
+        describe('when called with api key', () => {
+
+            let client;
+
+            before(() => {
+                client = new TVDB(API_KEY);
+            });
+
+            it('should store the api key', () => {
+                expect(client.apiKey).to.equal(API_KEY);
+            });
+
+            it('should set the default language (en)', () => {
+                expect(client.language).to.equal('en');
+            });
+
+        });
+
+        describe('when called with api key and language', () => {
+
+            let client;
+
+            before(() => {
+                client = new TVDB(API_KEY, 'ja');
+            });
+
+            it('should store the api key', () => {
+                expect(client.apiKey).to.equal(API_KEY);
+            });
+
+            it('should set the given language', () => {
+                expect(client.language).to.equal('ja');
+            });
+
+        });
+
+    });
+
+    describe('#getToken', () => {
+
+        describe('when api key is valid', () => {
+
+            let api, client;
+
+            before(() => {
+                api = nock(BASE_URL, {
+                    reqheaders: {
+                        'accept': AV_HEADER,
+                        'content-type': 'application/json'
+                    }
+                })
+                .post('/login', {
+                    apikey: API_KEY
+                })
+                .reply(200, {
+                    token: JWT_TOKEN
+                }, {
+                    'content-type': 'application/json; charset=utf-8'
+                });
+                client = new TVDB(API_KEY);
+            });
+
+            it('should call the /login endpoint', () => {
+                return expect(client.getToken()).to.be.fulfilled.then(() => {
+                    expect(api.isDone()).to.be.true;
+                });
+            });
+
+            it('should return a promise', () => {
+                expect(client.getToken()).to.be.instanceOf(Promise);
+            });
+
+            it('should yield the token from the api response', () => {
+                return expect(client.getToken()).to.eventually.equal(JWT_TOKEN);
+            });
+
+        });
+
+        describe('when api key is not valid', () => {
+
+            let api, client;
+
+            before(() => {
+                api = nock(BASE_URL, {
+                    reqheaders: {
+                        'accept': AV_HEADER,
+                        'content-type': 'application/json'
+                    }
+                })
+                .post('/login', {
+                    apikey: API_KEY
+                })
+                .reply(401, {
+                    Error: 'API Key Required'
+                }, {
+                    'content-type': 'application/json; charset=utf-8'
+                });
+                client = new TVDB(API_KEY);
+            });
+
+            it('should call the /login endpoint', () => {
+                return expect(client.getToken()).to.be.rejected.then(() => {
+                    expect(api.isDone()).to.be.true;
+                });
+            });
+
+            it('should throw the error from the api response', () => {
+                return expect(client.getToken()).to.be.rejectedWith(Error, 'Unauthorized - API Key Required');
+            });
+
+            it('should put the response on the error', () => {
+                return client.getToken().catch((e) => {
+                    expect(e.response).to.be.instanceOf(Body);
+                    expect(e.response.status).to.equal(401);
+                });
+            });
+
+        });
+
+        describe('when the api is down', () => {
+
+            let api, client;
+
+            before(() => {
+                api = nock(BASE_URL, {
+                    reqheaders: {
+                        'accept': AV_HEADER,
+                        'content-type': 'application/json'
+                    }
+                })
+                .post('/login', {
+                    apikey: API_KEY
+                })
+                .reply(522, '<HTML>', {
+                    'content-type': 'text/html; charset=utf-8'
+                });
+                client = new TVDB(API_KEY);
+            });
+
+            it('should call the /login endpoint', () => {
+                return expect(client.getToken()).to.be.rejected.then(() => {
+                    expect(api.isDone()).to.be.true;
+                });
+            });
+
+            it('should throw', () => {
+                return expect(client.getToken()).to.be.rejectedWith(Error);
+            });
+
+            it('should put the response on the error', () => {
+                return client.getToken().catch((e) => {
+                    expect(e.response).to.be.instanceOf(Body);
+                    expect(e.response.status).to.equal(522);
+                });
+            });
+
+        });
+
+    });
+
+    describe('#sendRequest', () => {
+
+        let client, getTokenSpy;
+
+        before(() => {
+            client = new TVDB(API_KEY);
+            getTokenSpy = sinon.stub(client, 'getToken', () => Promise.resolve(JWT_TOKEN));
+        });
+
+        describe('single page result', () => {
+
+            let api, p;
+            let data = [
+                {id: 0},
+                {id: 1},
+                {id: 2}
+            ];
+
+            before(() => {
+                getTokenSpy.reset();
+                api = nock(BASE_URL, {
+                    reqheaders: {
+                        'accept': AV_HEADER,
+                        'accept-language': 'en',
+                        'authorization': `Bearer ${JWT_TOKEN}`,
+                        'user-agent': AGENT_STRING
+                    }
+                })
+                .get('/some/path')
+                .reply(200, {
+                    data: data
+                }, {
+                    'content-type': 'application/json; charset=utf-8'
+                });
+                p = client.sendRequest('some/path');
+            });
+
+            it('should return a promise', () => {
+                expect(p).to.be.instanceOf(Promise);
+            });
+
+            it('should call getToken', () => {
+                return expect(p).to.be.fulfilled.then(() => {
+                    expect(getTokenSpy).to.have.been.calledOnce;
+                });
+            });
+
+            it('should call the specified endpoint', () => {
+                return expect(p).to.be.fulfilled.then(() => {
+                    expect(api.isDone()).to.be.true;
+                });
+            });
+
+            it('should resolve to the data returned by the api', () => {
+                return expect(p).to.eventually.deep.equal(data);
+            });
+
+        });
+
+        describe('multi page result', () => {
+
+            let api, p;
+            let data = [
+                {id: 0},
+                {id: 1},
+                {id: 2},
+                {id: 3},
+                {id: 4},
+                {id: 5}
+            ];
+
+            before(() => {
+                getTokenSpy.reset();
+                api = nock(BASE_URL, {
+                    reqheaders: {
+                        'accept': AV_HEADER,
+                        'accept-language': 'en',
+                        'authorization': `Bearer ${JWT_TOKEN}`,
+                        'user-agent': AGENT_STRING
+                    }
+                })
+                .get('/some/path')
+                .reply(200, {
+                    data: data.slice(0, 3),
+                    links: {
+                        next: 2
+                    }
+                }, {
+                    'content-type': 'application/json; charset=utf-8'
+                })
+                .get('/some/path?page=2')
+                .reply(200, {
+                    data: data.slice(3, 6)
+                }, {
+                    'content-type': 'application/json; charset=utf-8'
+                });
+                p = client.sendRequest('some/path');
+            });
+
+            it('should return a promise', () => {
+                expect(p).to.be.instanceOf(Promise);
+            });
+
+            it('should call getToken twice', () => {
+                return expect(p).to.be.fulfilled.then(() => {
+                    expect(getTokenSpy).to.have.been.calledTwice;
+                });
+            });
+
+            it('should call the specified endpoint twice', () => {
+                return expect(p).to.be.fulfilled.then(() => {
+                    expect(api.isDone()).to.be.true;
+                });
+            });
+
+            it('should resolve to the combined data returned by the api', () => {
+                return expect(p).to.eventually.deep.equal(data);
+            });
+
+        });
+
+        describe('when the api returns an error', () => {
+
+            let api, p;
+
+            before(() => {
+                getTokenSpy.reset();
+                api = nock(BASE_URL, {
+                    reqheaders: {
+                        'accept': AV_HEADER,
+                        'accept-language': 'en',
+                        'authorization': `Bearer ${JWT_TOKEN}`,
+                        'user-agent': AGENT_STRING
+                    }
+                })
+                .get('/some/path')
+                .reply(404, {
+                    Error: 'ID Not Found'
+                }, {
+                    'content-type': 'application/json; charset=utf-8'
+                });
+                p = client.sendRequest('some/path');
+            });
+
+            it('should return a promise', () => {
+                expect(p).to.be.instanceOf(Promise);
+            });
+
+            it('should call getToken', () => {
+                return expect(p).to.be.rejected.then(() => {
+                    expect(getTokenSpy).to.have.been.calledOnce;
+                });
+            });
+
+            it('should call the specified endpoint', () => {
+                return expect(p).to.be.rejected.then(() => {
+                    expect(api.isDone()).to.be.true;
+                });
+            });
+
+            it('should throw the error returned by the api', () => {
+                return expect(p).to.be.rejectedWith(Error, 'Not Found - ID Not Found');
+            });
+
+            it('should put the response on the error', () => {
+                return p.catch((e) => {
+                    expect(e.response).to.be.instanceOf(Body);
+                    expect(e.response.status).to.equal(404);
+                });
+            });
+
+        });
+
+        describe('when the api is down', () => {
+
+            let api, p;
+
+            before(() => {
+                getTokenSpy.reset();
+                api = nock(BASE_URL, {
+                    reqheaders: {
+                        'accept': AV_HEADER,
+                        'accept-language': 'en',
+                        'authorization': `Bearer ${JWT_TOKEN}`,
+                        'user-agent': AGENT_STRING
+                    }
+                })
+                .get('/some/path')
+                .reply(522, '<html>', {
+                    'content-type': 'text/html; charset=utf-8'
+                });
+                p = client.sendRequest('some/path');
+            });
+
+            it('should return a promise', () => {
+                expect(p).to.be.instanceOf(Promise);
+            });
+
+            it('should call getToken', () => {
+                return expect(p).to.be.rejected.then(() => {
+                    expect(getTokenSpy).to.have.been.calledOnce;
+                });
+            });
+
+            it('should call the specified endpoint', () => {
+                return expect(p).to.be.rejected.then(() => {
+                    expect(api.isDone()).to.be.true;
+                });
+            });
+
+            it('should throw', () => {
+                return expect(p).to.be.rejectedWith(Error);
+            });
+
+            it('should put the response on the error', () => {
+                return p.catch((e) => {
+                    expect(e.response).to.be.instanceOf(Body);
+                    expect(e.response.status).to.equal(522);
+                });
+            });
+
+        });
+
+    });
+
+});
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -116,7 +116,7 @@ chai-as-promised@^6.0.0:
   dependencies:
     check-error "^1.0.2"
 
-chai@^3.5.0:
+"chai@>=1.9.2 <4.0.0", chai@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"
   dependencies:
@@ -188,7 +188,7 @@ d@^0.1.1, d@~0.1.1:
   dependencies:
     es5-ext "~0.10.2"
 
-debug@2.2.0, debug@^2.1.1:
+debug@2.2.0, debug@^2.1.1, debug@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
@@ -199,6 +199,10 @@ deep-eql@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
   dependencies:
     type-detect "0.1.1"
+
+deep-equal@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -418,6 +422,12 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+formatio@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+  dependencies:
+    samsam "~1.1"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -502,6 +512,10 @@ inflight@^1.0.4:
 inherits@2, inherits@^2.0.3, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+inherits@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
 inquirer@^0.12.0:
   version "0.12.0"
@@ -616,6 +630,10 @@ json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
+json-stringify-safe@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+
 json3@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
@@ -688,9 +706,13 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.17.3, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.17.3, lodash@^4.3.0, lodash@~4.17.2:
   version "4.17.3"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.3.tgz#557ed7d2a9438cac5fd5a43043ca60cb455e01f7"
+
+lolex@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
 
 marked@~0.3.6:
   version "0.3.6"
@@ -743,6 +765,19 @@ mute-stream@0.0.5:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+nock@^9.0.9:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-9.0.9.tgz#ca4cd923352e206ae3c7d6595cfd7fb223299ec0"
+  dependencies:
+    chai ">=1.9.2 <4.0.0"
+    debug "^2.2.0"
+    deep-equal "^1.0.0"
+    json-stringify-safe "^5.0.1"
+    lodash "~4.17.2"
+    mkdirp "^0.5.0"
+    propagate "0.4.0"
+    qs "^6.0.2"
 
 node-fetch@^1.6.3:
   version "1.6.3"
@@ -822,6 +857,14 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
+propagate@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-0.4.0.tgz#f3fcca0a6fe06736a7ba572966069617c130b481"
+
+qs@^6.0.2:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
 ramda@^0.22.1:
   version "0.22.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.22.1.tgz#031da0c3df417c5b33c96234757eb37033f36a0e"
@@ -896,6 +939,10 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+samsam@1.1.2, samsam@~1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+
 shelljs@^0.7.5:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.5.tgz#2eef7a50a21e1ccf37da00df767ec69e30ad0675"
@@ -903,6 +950,19 @@ shelljs@^0.7.5:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+sinon-chai@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-2.8.0.tgz#432a9bbfd51a6fc00798f4d2526a829c060687ac"
+
+sinon@^1.17.7:
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+  dependencies:
+    formatio "1.1.1"
+    lolex "1.3.2"
+    samsam "1.1.2"
+    util ">=0.10.3 <1"
 
 slice-ansi@0.0.4:
   version "0.0.4"
@@ -1023,6 +1083,12 @@ user-home@^2.0.0:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+"util@>=0.10.3 <1":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
+  dependencies:
+    inherits "2.0.1"
 
 wordwrap@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fixes #82 

Promises returned by node-fetch are not rejected for status codes >= 400. This PR modifies the behavior of the internal `checkError()` function to detect status codes >= 400 and reject with useful error messages. This also required changing the order in which `checkError()` gets called. The rejection errors now also carry the full response object from node-fetch as `err.response`.

Also adds offline unit test coverage for the `Client` constructor and the `getToken()` and `sendRequest()` methods.