### PR TITLE
Use query urls when available

### DIFF
--- a/index.js
+++ b/index.js
@@ -288,21 +288,17 @@ class Client {
     }
 
     /**
-     * Get series images by series id.
+     * Get series images for a given key type.
      *
      * ``` javascript
-     * tvdb.getSeriesImages(73255)
-     *     .then(response => { handle response })
-     *     .catch(error => { handle error });
-     *
      * // request only return fan art images:
-     * const queryOptions = { keyType: 'fanart' }
-     * tvdb.getSeriesImages(73255, { query: queryOptions })
+     * tvdb.getSeriesImages(73255, 'fanart', { query: queryOptions })
      *     .then(response => { handle response })
      *     .catch(error => { handle error });
      * ```
      *
      * @param   {Number|String} seriesId
+     * @param   {String}        keyType - the key type to query by
      * @param   {Object}        [opts] - additional options for request
      * @returns {Promise}
      *
@@ -311,11 +307,16 @@ class Client {
      * @public
      */
 
-    getSeriesImages(seriesId, opts) {
-        if (opts && opts.query) {
-            return this.sendRequest(`series/${seriesId}/images/query`, opts);
+    getSeriesImages(seriesId, keyType, opts) {
+        let query = {};
+        if (keyType !== null) {
+            query = { query: {
+                keyType: keyType }
+            };
         }
-        return this.sendRequest(`series/${seriesId}/images`, opts);
+        const reqOpts = Object.assign({}, opts, query);
+
+        return this.sendRequest(`series/${seriesId}/images/query`, reqOpts);
     }
 
     /**
@@ -335,10 +336,7 @@ class Client {
      * @public
      */
     getSeriesPosters(seriesId, opts) {
-        const query = { keyType: 'poster' };
-        const reqOpts = Object.assign({}, opts, { query: query });
-
-        return this.getSeriesImages(seriesId, reqOpts);
+        return this.getSeriesImages(seriesId, 'poster', opts);
     }
 
     /**
@@ -362,7 +360,7 @@ class Client {
         const query = { keyType: 'season', subKey: season };
         const reqOpts = Object.assign({}, opts, { query: query });
 
-        return this.getSeriesImages(seriesId, reqOpts);
+        return this.getSeriesImages(seriesId, null, reqOpts);
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -294,6 +294,12 @@ class Client {
      * tvdb.getSeriesImages(73255)
      *     .then(response => { handle response })
      *     .catch(error => { handle error });
+     *
+     * // request only return fan art images:
+     * const queryOptions = { keyType: 'fanart' }
+     * tvdb.getSeriesImages(73255, { query: queryOptions })
+     *     .then(response => { handle response })
+     *     .catch(error => { handle error });
      * ```
      *
      * @param   {Number|String} seriesId

--- a/index.js
+++ b/index.js
@@ -349,7 +349,7 @@ class Client {
      * @param   {Object}        [opts] - additional options for request
      * @returns {Promise}
      *
-     * @see     https://api.thetvdb.com/swagger#!/Series/get_series_id_filter
+     * @see     https://api.thetvdb.com/swagger#!/Series/get_series_id_images_query
      * @public
      */
     getSeasonPosters(seriesId, season, opts) {

--- a/index.js
+++ b/index.js
@@ -167,7 +167,8 @@ class Client {
     getEpisodesByAirDate(seriesId, airDate, opts) {
         const query = { firstAired: airDate };
         const reqOpts = Object.assign({}, opts, { query: query });
-        return this.sendRequest(`series/${seriesId}/episodes/query`, reqOpts);
+
+        return this.getEpisodesBySeriesId(seriesId, reqOpts);
     }
 
     /**
@@ -280,12 +281,39 @@ class Client {
     getSeriesBanner(seriesId, opts) {
         const query = { keys: 'banner' };
         const reqOpts = Object.assign({}, opts, { query: query });
-        return this.sendRequest(`series/${seriesId}/filter`, reqOpts)
-            .then(response => response.banner);
+
+        return this.sendRequest(`series/${seriesId}/filter`, reqOpts).then(response => {
+            return response.banner;
+        });
     }
 
     /**
-     * Get series poster by series id.
+     * Get series images by series id.
+     *
+     * ``` javascript
+     * tvdb.getSeriesImages(73255)
+     *     .then(response => { handle response })
+     *     .catch(error => { handle error });
+     * ```
+     *
+     * @param   {Number|String} seriesId
+     * @param   {Object}        [opts] - additional options for request
+     * @returns {Promise}
+     *
+     * @see     https://api.thetvdb.com/swagger#!/Series/get_series_id_images
+     * @see     https://api.thetvdb.com/swagger#!/Series/get_series_id_images_query
+     * @public
+     */
+
+    getSeriesImages(seriesId, opts) {
+        if (opts && opts.query) {
+            return this.sendRequest(`series/${seriesId}/images/query`, opts);
+        }
+        return this.sendRequest(`series/${seriesId}/images`, opts);
+    }
+
+    /**
+     * Convenience wrapper around `getSeriesImages` to only return poster images for a series.
      *
      * ``` javascript
      * tvdb.getSeriesPosters(73255)
@@ -297,17 +325,18 @@ class Client {
      * @param   {Object}        [opts] - additional options for request
      * @returns {Promise}
      *
-     * @see     https://api.thetvdb.com/swagger#!/Series/get_series_id_filter
+     * @see     https://api.thetvdb.com/swagger#!/Series/get_series_id_images_query
      * @public
      */
     getSeriesPosters(seriesId, opts) {
         const query = { keyType: 'poster' };
         const reqOpts = Object.assign({}, opts, { query: query });
-        return this.sendRequest(`series/${seriesId}/images/query`, reqOpts);
+
+        return this.getSeriesImages(seriesId, reqOpts);
     }
 
     /**
-     * Get season poster by series id and season.
+     * Convenience wrapper around `getSeriesImages` to only return season poster images for a series.
      *
      * ``` javascript
      * tvdb.getSeasonPosters(73255, 1)
@@ -326,7 +355,8 @@ class Client {
     getSeasonPosters(seriesId, season, opts) {
         const query = { keyType: 'season', subKey: season };
         const reqOpts = Object.assign({}, opts, { query: query });
-        return this.sendRequest(`series/${seriesId}/images/query`, reqOpts);
+
+        return this.getSeriesImages(seriesId, reqOpts);
     }
 
     /**

--- a/test/getSeasonPosters.js
+++ b/test/getSeasonPosters.js
@@ -21,7 +21,7 @@ describe('#getSeasonPosters', () => {
             response.forEach(poster => {
                 expect(poster).to.contain.all.keys('id', 'keyType', 'subKey', 'fileName', 'resolution', 'ratingsInfo', 'thumbnail');
                 expect(poster.keyType).to.equal('season');
-                expect(poster.fileName).to.contain('seasons/80379-10');
+                expect(poster.subKey).to.equal('10');
             });
         });
     });

--- a/test/getSeriesImages.js
+++ b/test/getSeriesImages.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const TVDB = require('..');
+const API_KEY = process.env.TVDB_KEY;
+
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const expect = chai.expect;
+
+chai.use(chaiAsPromised);
+
+describe('#getSeriesImages', () => {
+
+    it('should return an array of the images for the series with id "73255"', () => {
+        const tvdb = new TVDB(API_KEY);
+
+        return tvdb.getSeriesImages(71663).then(response => {
+            expect(response).to.be.an('object');
+            expect(response).to.contain.all.keys('fanart', 'poster', 'season', 'series');
+
+            expect(response.poster).to.be.an('array');
+            expect(response.poster).to.not.be.empty;
+        });
+    });
+
+});

--- a/test/getSeriesImages.js
+++ b/test/getSeriesImages.js
@@ -11,15 +11,17 @@ chai.use(chaiAsPromised);
 
 describe('#getSeriesImages', () => {
 
-    it('should return an array of the images for the series with id "73255"', () => {
+    it('should return an array of the fanart images for the series with id "73255"', () => {
         const tvdb = new TVDB(API_KEY);
 
-        return tvdb.getSeriesImages(71663).then(response => {
-            expect(response).to.be.an('object');
-            expect(response).to.contain.all.keys('fanart', 'poster', 'season', 'series');
+        return tvdb.getSeriesImages(71663, 'fanart').then(response => {
+            expect(response).to.be.an('array');
+            expect(response).to.not.be.empty;
 
-            expect(response.poster).to.be.an('array');
-            expect(response.poster).to.not.be.empty;
+            response.forEach(poster => {
+                expect(poster).to.contain.all.keys('id', 'keyType', 'subKey', 'fileName', 'resolution', 'ratingsInfo', 'thumbnail');
+                expect(poster.keyType).to.equal('fanart');
+            });
         });
     });
 


### PR DESCRIPTION
Some endpoints offer filter/query urls and these should be made available and used where appropriate.

In the case of `getSeriesPosters` and `getSeasonPosters` for example, they're really just convenience methods over the query images endpoint.
